### PR TITLE
Adding capability to set zone for bastion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ clean:
 	@rm -rf dist
 
 .PHONY: gen
-gen:
-	bazel-bin/darwin_amd64_stripped/gke-tf gen -d /tmp/tf/ -f examples/example.yaml -o -p ${PROJECT}
+gen: build
+	bazel-bin/darwin_amd64_stripped/gke-tf gen -d /tmp/tf/ -f examples/full.yaml -o -p ${PROJECT}
 
 lint: check_shell check_python check_golang check_terraform check_docker \
 	check_base_files check_headers check_trailing_whitespace

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -22,6 +22,7 @@ filegroup(
         "test-data.yaml",
         "public-example.yaml",
         "min-example.yaml",
+        "full.yaml",
     ],
     visibility = ["//visibility:public"],
 )

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -23,6 +23,7 @@ spec:
   #- us-east4-a
   #- us-east4-c
   #databaseEncryption:
+  #  replace this with the existing kms key
   #  keyName: "projects/myproject/locations/us-central1/keyRings/myring/cryptoKeys/mykey"
   #  state: "ENCRYPTED"
   #resourceUsageExportConfig:
@@ -60,11 +61,15 @@ spec:
   #  - key: "testall"
   #    value: "valueall"
   #    effect: "NO_SCHEDULE"
-  workloadIdentityConfig:
-    identityNamespace: "bgeesaman-gke-demos.svc.id.goog"
+  # workloadIdentityConfig:
+  # replace with correct values that match you project
+  #  identityNamespace: "bgeesaman-gke-demos.svc.id.goog"
   defaultMaxPodsPerNode: 110
   tpu: false
   alpha: false
+  bastion:
+    spec:
+      zone: "us-east4-c"
   nodePools:
     - metadata:
         name: gketf-node-pool
@@ -89,7 +94,8 @@ spec:
         - "https://www.googleapis.com/auth/trace.append"
         labels:
           seven: "eight"
-        serviceAccount: "gketf-1-node-sa@bgeesaman-gke-demos.iam.gserviceaccount.com"
+        # replace the following line with the existing service account
+        # serviceAccount: "gketf-1-node-sa@my-project.iam.gserviceaccount.com"
         workloadMetadataConfig:
           nodeMetadata: "GKE_METADATA_SERVER"
     - metadata:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,10 +21,7 @@ import (
 	"io/ioutil"
 )
 
-// TODO add nvida card values
-
 // TODO add bastion
-// TODO add nat gateway
 
 // GkeTF is the base layer for the API.  It includes a ClusterSpec and other obligatory information.
 type GkeTF struct {
@@ -130,6 +127,9 @@ type ClusterSpec struct {
 	// https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility
 	// Requires enabling VPC flow logs on the subnet first
 	IntraNodeVisibility string `yaml:"intraNodeVisibility,omitempty" default:"false" validate:"eq=true|eq=false"`
+
+	// Bastion defines configuration specific for the bastion created with a private clusters.
+	Bastion *GkeBastion `yaml:"bastion,omitempty"` // TODO validate
 }
 
 // GkeNetwork wraps a NetworkSpec.
@@ -157,6 +157,21 @@ type NetworkSpec struct {
 	// TODO test for this - The given master_ipv4_cidr 10.0.0.0/28 overlaps with an existing network 10.0.0.0/24.
 	// TODO we make have to make MasterIPV4CIDRBlock required if it is a private cluster.  Need more testing.
 
+}
+
+// GkeBastion wraps a BastionSpec.
+type GkeBastion struct {
+	TypeMeta   `yaml:",inline"`
+	ObjectMeta `yaml:"metadata,omitempty"`
+
+	// BastionSpec includes the base information for a bastion host that is used with a private cluster. This allows a user to define the zone for a bastion, if not defined the zone will default to the "a" zone.
+	Spec BastionSpec `yaml:"spec" validate:"required,dive"`
+}
+
+// BastionSpec includes the base information for a bastion host that is used with a private cluster.
+type BastionSpec struct {
+	// Zone defines the zone where the bastion host is created.
+	Zone string `yaml:"zone" validate:"required"`
 }
 
 // GkeNetwork wraps a NodePoolSpec.
@@ -297,11 +312,11 @@ type NodePoolSpec struct {
 
 // Defines how pods on this node pool can interact (or not) with the GCE Metadata APIs.
 // https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-// UNSPECIFIED = not set, EXPOSED = off, SECURE = Metadata Concealment, 
+// UNSPECIFIED = not set, EXPOSED = off, SECURE = Metadata Concealment,
 // GKE_METADATA_SERVER = workload identity and metadata concealment combined.
 type WorkloadMetadataConfigSpec struct {
 	// How to expose the node metadata to the workload running on the node.
-        // https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_metadata
+	// https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_metadata
 	NodeMetadata *string `yaml:"nodeMetadata" validate:"required,eq=UNSPECIFIED|eq=EXPOSED|eq=SECURE|eq=GKE_METADATA_SERVER"`
 }
 

--- a/pkg/terraform/vanilla/network.tf.tmpl
+++ b/pkg/terraform/vanilla/network.tf.tmpl
@@ -134,6 +134,13 @@ resource "google_compute_router_nat" "nat" {
 // Bastion Host
 locals {
   hostname = format("%s-bastion", var.cluster_name)
+  {{- if .Spec.Bastion }}
+  bastion_zone = "{{.Spec.Bastion.Spec.Zone}}"
+  {{- else }}
+  // If zone a does not exist in a region please create a yaml spec for the bastion.
+  // TODO update this debug statement
+  bastion_zone = format("%s-a", var.region)
+  {{- end }}
 }
 
 // Dedicated service account for the Bastion instance
@@ -164,14 +171,15 @@ data "template_file" "startup_script" {
   sudo apt-get update -y
   sudo apt-get install -y tinyproxy
   EOF
-
 }
+
+// TODO add more options for bastion
 
 // The Bastion Host
 resource "google_compute_instance" "instance" {
   name = local.hostname
   machine_type = "g1-small"
-  zone = format("%s-a", var.region)
+  zone = local.bastion_zone
   project = var.project_id
   tags = ["bastion"]
 
@@ -212,7 +220,7 @@ resource "google_compute_instance" "instance" {
     command = <<EOF
         READY=""
         for i in $(seq 1 20); do
-          if gcloud compute ssh ${local.hostname} --project ${var.project_id} --zone ${var.region}-a --command uptime; then
+          if gcloud compute ssh ${local.hostname} --project ${var.project_id} --zone ${local.bastion_zone} --command uptime; then
             READY="yes"
             break;
           fi


### PR DESCRIPTION
Added capability to set a zone value for the bastion, because some regions do not have 'a' zone.

- Added new api structure for the bastion
- Updated full.yaml with new api values
- Modified network.tf.tmpl to support api values
- Updated unit test to test changes
- Modified Makefile to use full.yaml
- commented out some values in full.yaml that are project specific

Fixes: https://github.com/GoogleCloudPlatform/gke-terraform-generator/issues/6